### PR TITLE
Feature/994 safe updates

### DIFF
--- a/lib/safe/client.rb
+++ b/lib/safe/client.rb
@@ -80,6 +80,29 @@ module SAFE
       end
     end
 
+    def find_not_finished_workflow_by(params)
+      matching = nil
+      connection_pool.with do |redis|
+        redis.scan_each(match: "safe.workflows.*") do |key|
+          hash = SAFE::JSON.decode(redis.get(key), symbolize_keys: true)
+          matching =  hash if hash[:status] != 'finished' && params.all? { |k, v| hash[k] == v }
+        end
+      end
+
+      return false unless matching
+
+      if matching.has_key?(:linked_type)
+        begin
+          matching[:linked_type].constantize.find(matching[:linked_id])
+          find_workflow(matching[:id])
+        rescue ActiveRecord::RecordNotFound => e
+          false
+        end
+      else
+        find_workflow(matching[:id])
+      end
+    end
+
     def find_workflow(id)
       connection_pool.with do |redis|
         data = redis.get("safe.workflows.#{id}")
@@ -194,6 +217,8 @@ module SAFE
       flow.jobs = []
       flow.stopped = hash.fetch(:stopped, false)
       flow.id = hash[:id]
+      flow.linked_type = hash[:linked_type]
+      flow.linked_id = hash[:linked_id]
 
       if monitor = MonitorClient.load_workflow(flow)
         flow.monitor = monitor

--- a/lib/safe/client.rb
+++ b/lib/safe/client.rb
@@ -155,7 +155,7 @@ module SAFE
     def expire_job(workflow_id, job, ttl=nil)
       ttl = ttl || configuration.ttl
       connection_pool.with do |redis|
-        redis.expire("safe.jobs.#{workflow_id}.#{job.name}", ttl)
+        redis.expire("safe.jobs.#{workflow_id}.#{job.klass}", ttl)
       end
     end
 

--- a/lib/safe/monitor_client.rb
+++ b/lib/safe/monitor_client.rb
@@ -32,20 +32,19 @@ module SAFE
       private
 
       def create_workflow(workflow, monitorable)
-        WorkflowMonitor.where(
+        monitor = WorkflowMonitor.where(
           workflow:    workflow.class.to_s,
-          workflow_id: workflow.id,
           monitorable: monitorable
-        ).first_or_create!
+        ).first_or_initialize
+
+        monitor.init(workflow.id)
+        monitor
       end
 
       def create_jobs(jobs, monitor)
         jobs.each do |job|
-          monitor.jobs.where(
-            job:    job.class.to_s,
-            job_id: job.id,
-            total:  job.total_steps
-          ).first_or_create!
+          _job = monitor.jobs.where(job: job.class.to_s).first_or_initialize
+          _job.init(job)
         end
       end
 

--- a/lib/safe/rails/models/safe/job_monitor.rb
+++ b/lib/safe/rails/models/safe/job_monitor.rb
@@ -3,7 +3,7 @@ module SAFE
 
     belongs_to :workflow_monitor
 
-    has_many :error_occurrences, dependent: :destroy
+    has_many :error_occurrences, dependent: :delete_all
 
     validates :failures, :job, :job_id, :successes, :total, :workflow_monitor,
       presence: true
@@ -12,6 +12,16 @@ module SAFE
       numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 
     attr_readonly :total
+
+    def init(_job)
+      self.job_id    = _job.id
+      self.failures  = 0
+      self.successes = 0
+      self.total     = _job.total_steps
+
+      error_occurrences.clear
+      save
+    end
 
     def monitorable
       @monitorable ||= client.find_job(workflow_monitor.workflow_id, job)

--- a/lib/safe/rails/models/safe/workflow_monitor.rb
+++ b/lib/safe/rails/models/safe/workflow_monitor.rb
@@ -23,6 +23,11 @@ module SAFE
       workflow_klass.find(workflow_id).status
     end
 
+    def init(flow_id)
+      self.workflow_id = flow_id
+      save
+    end
+
     private
 
     def workflow_klass

--- a/lib/safe/worker.rb
+++ b/lib/safe/worker.rb
@@ -24,6 +24,8 @@ module SAFE
       else
         mark_as_finished
         enqueue_outgoing_jobs
+      ensure
+        set_flow_expiration
       end
     end
 
@@ -49,6 +51,11 @@ module SAFE
           output: job.output_payload
         }
       end
+    end
+
+    def set_flow_expiration
+      flow = client.find_workflow(workflow_id)
+      flow.expire! if flow.finished?
     end
 
     def mark_as_finished

--- a/lib/safe/worker.rb
+++ b/lib/safe/worker.rb
@@ -25,7 +25,7 @@ module SAFE
         mark_as_finished
         enqueue_outgoing_jobs
       ensure
-        set_flow_expiration
+        update_workflow
       end
     end
 
@@ -53,8 +53,9 @@ module SAFE
       end
     end
 
-    def set_flow_expiration
+    def update_workflow
       flow = client.find_workflow(workflow_id)
+      client.persist_workflow(flow)
       flow.expire! if flow.finished?
     end
 

--- a/lib/safe/workflow.rb
+++ b/lib/safe/workflow.rb
@@ -2,7 +2,7 @@ require 'securerandom'
 
 module SAFE
   class Workflow
-    attr_accessor :id, :jobs, :stopped, :persisted, :arguments, :monitor
+    attr_accessor :id, :jobs, :stopped, :persisted, :arguments, :monitor, :linked_type, :linked_id
     attr_reader :linked_record
 
     def initialize(*args)
@@ -63,14 +63,14 @@ module SAFE
       end
 
       def find_running(new_flow)
-        client.all_workflows.each do |flow|
-          if new_flow.linked_record
-            return flow if flow.to_hash[:name] == new_flow.class.to_s && !flow.finished? && new_flow.linked_record == flow.linked_record && flow.monitor
-          else
-            return flow if flow.to_hash[:name] == new_flow.class.to_s && flow.running?
-          end
-        end
-        return false
+        params = { klass: new_flow.class.to_s }
+
+        params.merge!({
+          linked_type: new_flow.linked_record.class.to_s,
+          linked_id:   new_flow.linked_record.id.to_i
+        }) if new_flow.linked_record
+
+        client.find_not_finished_workflow_by(params)
       end
     end
 
@@ -234,6 +234,14 @@ module SAFE
         stopped: stopped,
         started_at: started_at,
         finished_at: finished_at
+      }.merge!(linked_obj_attrs)
+    end
+
+    def linked_obj_attrs
+      return {} unless linked_record && linked_record.respond_to?(:id)
+      {
+        linked_type: linked_record.class.to_s,
+        linked_id:   linked_record.id
       }
     end
 

--- a/spec/features/integration_spec.rb
+++ b/spec/features/integration_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe "Workflows" do
     # One time when persisting, second time when reloading in the spec
     expect(INTERNAL_CONFIGURE_SPY).to receive(:some_method).exactly(2).times
 
-    allow_any_instance_of(SAFE::Worker).to receive(:set_flow_expiration)
+    allow_any_instance_of(SAFE::Worker).to receive(:update_workflow)
 
     class SimpleJob < SAFE::Job
       def perform

--- a/spec/safe/client_spec.rb
+++ b/spec/safe/client_spec.rb
@@ -98,9 +98,14 @@ describe SAFE::Client do
     it "sets TTL for all Redis keys related to the workflow" do
       workflow = TestWorkflow.create
 
-      client.expire_workflow(workflow, -1)
+      client.expire_workflow(workflow, 10)
+      expect(redis.ttl("safe.workflows.#{workflow.id}")).to eq 10
 
-      # => TODO - I believe fakeredis does not handle TTL the same.   
+      jobs = workflow.jobs.map(&:klass)
+
+      jobs.each do |job|
+        expect(redis.ttl("safe.jobs.#{workflow.id}.#{job}")).to eq 10
+      end
     end
   end
 

--- a/spec/safe/worker_spec.rb
+++ b/spec/safe/worker_spec.rb
@@ -38,7 +38,7 @@ describe SAFE::Worker do
       end
 
       it 'try to set flow expiration' do
-        expect(subject).to receive(:set_flow_expiration)
+        expect(subject).to receive(:update_workflow)
 
         subject.perform(workflow.id, "Prepare")
       end

--- a/spec/safe/worker_spec.rb
+++ b/spec/safe/worker_spec.rb
@@ -24,9 +24,8 @@ describe SAFE::Worker do
         end
 
         workflow = FailingWorkflow.create
-        expect do
-          subject.perform(workflow.id, "FailingJob")
-        end.to raise_error(NameError)
+
+        expect { subject.perform(workflow.id, "FailingJob") }.to raise_error(NameError)
         expect(client.find_job(workflow.id, "FailingJob")).to be_failed
       end
     end
@@ -34,6 +33,12 @@ describe SAFE::Worker do
     context "when job completes successfully" do
       it "should mark it as succedeed" do
         expect(subject).to receive(:mark_as_finished)
+
+        subject.perform(workflow.id, "Prepare")
+      end
+
+      it 'try to set flow expiration' do
+        expect(subject).to receive(:set_flow_expiration)
 
         subject.perform(workflow.id, "Prepare")
       end

--- a/spec/safe/workflow_spec.rb
+++ b/spec/safe/workflow_spec.rb
@@ -103,6 +103,8 @@ module SAFE
         end
 
         context 'active record persistence' do
+          before { WorkflowMonitor.destroy_all }
+
           it 'create a WorkflowMonitor record' do
             expect{ TestWorkflow.create }.to change(WorkflowMonitor, :count).by(1)
           end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -121,7 +121,8 @@ RSpec.configure do |config|
 
     SAFE.configure do |config|
       config.redis_url = REDIS_URL
-      config.safefile = SAFEFILE
+      config.safefile  = SAFEFILE
+      config.ttl       = 10
     end
   end
 


### PR DESCRIPTION
Pessoal, esse PR implementa algumas novas features para o SAFE:

- Expira keys do redis por padrão, basta setar o TTL na aplicação;
- Cria apenas um registro no banco de dados para cada conjunto de `Workflow` + `monitorable`;
- Reimplementa a forma de obtenção de workflow já existente, evitando que todo o processo quebre caso algum registro do banco de dados seja deletado e ainda exista no redis. (Ex: Se a key de workflow não expirar e uma `Payroll` tiver sido associada a ela e essa `Payroll` tenha sido deletada do banco. Ao utilizar o `create_unique` o processo estourava pois a payroll não existia mais e não podia ser linkada.

ps: O código em si não tá nem um pouco bonito ou ótimamente escrito, mas tá testado e funcionando. Assim que tiver uns minutos vou refatorar pra remover duplicações e deixar tudo mais belo e claro. Por enquanto vai assim que já funciona e liberamos o QA o quanto antes